### PR TITLE
Add spatial similarity

### DIFF
--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -85,6 +85,12 @@ create_bins() {
 }
 
 convert_state_assignments() {
+  # ChromHMM's state assignment files are created in a way to be memory 
+  # efficient. If multiple bins have the same state assignment, they are
+  # collapsed into one. This is not ideal for this pipeline as we want to
+  # count the number of base pairs assigned to each state pair. By converting
+  # these files to no longer be collapsed, the code becomes more efficient and
+  # easier to follow.
   sorted_blank_bins_file=$1
   state_assignment_file=$2
   output_file_path=$3

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -68,9 +68,15 @@ run_emission_similarity() {
 run_spatial_similarity() {
   state_assignment_file_one=$1
   state_assignment_file_two=$2
-  emission_file_one=$3
-  emission_file_two=$4
+  bin_size=$3
+  chromosome_sizes_file=$4
   output_file=$5
+
+  Rscript \
+    "${RSCRIPT_DIRECTORY}/create_blank_bed_file" \
+    "${bin_size}" \
+    "${state_assignment_file_one}" \
+    "${chromosome_sizes_file}"
 
   shift 5
   margins=("$@")
@@ -79,8 +85,6 @@ run_spatial_similarity() {
       "${RSCRIPT_DIRECTORY}/spatial_similarity.R" \
       "${state_assignment_file_one}" \
       "${state_assignment_file_two}" \
-      "${emission_file_one}" \
-      "${emission_file_two}" \
       "${margin}" \
       "${output_file}"
   done
@@ -126,6 +130,8 @@ main() {
     "${MODEL_ONE_STATE_ASSIGNMENTS_FILE}" \
     "${MODEL_ONE_EMISSIONS_FILE}" \
     "${MODEL_TWO_EMISSIONS_FILE}" \
+    "${BIN_SIZE}" \
+    "${CHROMOSOME_SIZES_FILE}" \
     "${state_assignments_similarity_file}" \
     "${margins[@]}"
 

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -107,8 +107,7 @@ run_spatial_similarity() {
   state_assignment_file_one=$1
   state_assignment_file_two=$2
   bin_size=$3
-  chromosome_sizes_file=$4
-  output_file=$5
+  output_file=$4
 
 
   shift 5

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -65,7 +65,7 @@ run_emission_similarity() {
     "${output_file}"
 }
 
-create_bins() {
+create_blank_bins() {
   state_assignment_file_one=$1
   bin_size=$2
   chromosome_sizes_file=$3
@@ -158,7 +158,9 @@ main() {
   source_config_file "${config_file_location}"
   move_log_files
 
-  mkdir "${OUTPUT_DIRECTORY}/similarity_scores"
+  mkdir -p \
+    "${OUTPUT_DIRECTORY}/similarity_scores" \
+    "${PROCESSING_DIRECTORY}"
 
   emission_similarities_file="${PROCESSING_DIRECTORY}/similarity_scores/emission_similarity.txt"
   run_emission_similarity \
@@ -166,7 +168,7 @@ main() {
     "${MODEL_TWO_EMISSIONS_FILE}" \
     "${emission_similarities_file}"
 
-  create_bins \
+  create_blank_bins \
     "${MODEL_ONE_STATE_ASSIGNMENTS_FILE}" \
     "${BIN_SIZE}" \
     "${CHROMOSOME_SIZES_FILE}" \

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -138,6 +138,7 @@ run_spatial_similarity() {
     Rscript \
       "${RSCRIPT_DIRECTORY}/spatial_similarity.R" \
       "${PROCESSING_DIRECTORY}/state_assignment_overlap_margin_${margin}.bed" \
+      "${bin_size}" \
       "${output_file_prefix}${margin}.txt"
   done
 }

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -132,7 +132,7 @@ run_spatial_similarity() {
       "${RSCRIPT_DIRECTORY}/spatial_similarity.R" \
       "${PROCESSING_DIRECTORY}/state_assignments_one_margin_${margin}.bed" \
       "${PROCESSING_DIRECTORY}/state_assignments_two_margin_${margin}.bed" \
-      "${output_file_prefix}_${margin}.txt"
+      "${output_file_prefix}${margin}.txt"
   done
 }
 
@@ -187,7 +187,7 @@ main() {
     "${PROCESSING_DIRECTORY}/state_assignments_model_two.bed"
 
   margins=(0 "${BIN_SIZE}" $((BIN_SIZE * 10)))
-  state_assignments_similarity_file_prefix="${PROCESSING_DIRECTORY}/similarity_scores/state_assignment_similarity"
+  state_assignments_similarity_file_prefix="${PROCESSING_DIRECTORY}/similarity_scores/state_assignment_similarity_margin_"
   run_spatial_similarity \
     "${PROCESSING_DIRECTORY}/state_assignments_model_one.bed"
     "${PROCESSING_DIRECTORY}/state_assignments_model_two.bed"

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -113,7 +113,7 @@ run_spatial_similarity() {
   output_file_prefix=$4
 
 
-  shift 5
+  shift 4
   margins=("$@")
   for margin in "${margins[@]}"; do
     Rscript \
@@ -189,8 +189,8 @@ main() {
   margins=(0 "${BIN_SIZE}" $((BIN_SIZE * 10)))
   state_assignments_similarity_file_prefix="${PROCESSING_DIRECTORY}/similarity_scores/state_assignment_similarity"
   run_spatial_similarity \
-    "${MODEL_ONE_STATE_ASSIGNMENTS_FILE}" \
-    "${MODEL_TWO_STATE_ASSIGNMENTS_FILE}" \
+    "${PROCESSING_DIRECTORY}/state_assignments_model_one.bed"
+    "${PROCESSING_DIRECTORY}/state_assignments_model_two.bed"
     "${BIN_SIZE}" \
     "${state_assignments_similarity_file_prefix}" \
     "${margins[@]}"

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -77,6 +77,18 @@ run_spatial_similarity() {
     "${bin_size}" \
     "${state_assignment_file_one}" \
     "${chromosome_sizes_file}"
+    "${PROCESSING_DIRECTORY}/blank_bins.bed"
+
+  bedtools sort -i \
+    "${PROCESSING_DIRECTORY}/blank_bins.bed" > \
+    "${PROCESSING_DIRECTORY}/sorted_blank_bins.bed"
+
+  bedtools intersect \
+    -wb \
+    -a "${PROCESSING_DIRECTORY}/sorted_blank_bins.bed" \
+    -b "${state_assignment_file_one}" | \
+    awk '{OFS = "\t"} {print $1,$2,$3,$7}' > \
+    "${PROCESSING_DIRECTORY}/state_assignment_file_one.bed"
 
   shift 5
   margins=("$@")

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -131,7 +131,7 @@ run_spatial_similarity() {
       -wo \
       -a "${PROCESSING_DIRECTORY}/state_assignments_one_margin_${margin}.bed" \
       -b "${PROCESSING_DIRECTORY}/state_assignments_two_margin_${margin}.bed" | \
-      awk '{OFS="\t"} {print $4,$8}' > \
+      awk '{OFS="\t"} {print $4,$8,$9}' > \
       "${PROCESSING_DIRECTORY}/state_assignment_overlap_margin_${margin}.bed"
 
 

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -112,7 +112,6 @@ run_spatial_similarity() {
   bin_size=$3
   output_file_prefix=$4
 
-
   shift 4
   margins=("$@")
   for margin in "${margins[@]}"; do
@@ -128,10 +127,17 @@ run_spatial_similarity() {
       "${margin}" \
       "${PROCESSING_DIRECTORY}/state_assignments_two_margin_${margin}.bed"
 
+    bedtools intersect \
+      -wo \
+      -a "${PROCESSING_DIRECTORY}/state_assignments_one_margin_${margin}.bed" \
+      -b "${PROCESSING_DIRECTORY}/state_assignments_two_margin_${margin}.bed" | \
+      awk '{OFS="\t"} {print $4,$8}' > \
+      "${PROCESSING_DIRECTORY}/state_assignment_overlap_margin_${margin}.bed"
+
+
     Rscript \
       "${RSCRIPT_DIRECTORY}/spatial_similarity.R" \
-      "${PROCESSING_DIRECTORY}/state_assignments_one_margin_${margin}.bed" \
-      "${PROCESSING_DIRECTORY}/state_assignments_two_margin_${margin}.bed" \
+      "${PROCESSING_DIRECTORY}/state_assignment_overlap_margin_${margin}.bed" \
       "${output_file_prefix}${margin}.txt"
   done
 }

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -78,6 +78,9 @@ create_blank_bins() {
     "${chromosome_sizes_file}" \
     "${PROCESSING_DIRECTORY}/blank_bins.bed"
 
+  # Sorting required for later bedtools intersect. The output of the Rscript is
+  # most likely sorted alphabetically rather than numerically (for chromosome
+  # order)
   bedtools sort -i \
     "${PROCESSING_DIRECTORY}/blank_bins.bed" > \
     "${output_file}"

--- a/Rscripts/add_margins.R
+++ b/Rscripts/add_margins.R
@@ -72,4 +72,5 @@ margin <- as.numeric(args[[2]])
 chromosome_sizes_file <- args[[3]]
 output_file_path <- args[[4]]
 
+options(scipen = 12)
 main(state_assignments_file, margin, chromosome_sizes_file, output_file_path)

--- a/Rscripts/add_margins.R
+++ b/Rscripts/add_margins.R
@@ -21,7 +21,7 @@ correct_invalid_bounds <- function(state_assignments, chromosome_sizes) {
   # into the negatives. We need to correct for such bounds.
   state_assignments <- dplyr::mutate(
     state_assignments,
-    start = ifelse(state < 0, 0, start)
+    start = ifelse(start < 0, 0, start)
   )
   present_chromosomes <- unique(state_assignments[["chr"]])
   for (chromosome in present_chromosomes) {
@@ -29,8 +29,8 @@ correct_invalid_bounds <- function(state_assignments, chromosome_sizes) {
     state_assignments <- dplyr::mutate(
       state_assignments,
       end = ifelse(
-        end > chromosome_size && chr == chromosome,
-        chromosome_size,
+        end > chromosome_size,
+        ifelse(chr == chromosome, chromosome_size, end),
         end
       )
     )

--- a/Rscripts/add_margins.R
+++ b/Rscripts/add_margins.R
@@ -1,6 +1,11 @@
 main <- function(state_assignments_file, margin) {
   state_assignments <- data.table::fread(state_assignments_file)
   state_assignments <- add_margins(state_assignments)
+add_margins <- function(state_assignments, margin) {
+  state_assignments <- state_assignments |>
+    dplyr::mutate(start = start - margin, end = end + margin)
+}
+  state_assignments <- add_margins(state_assignments, margin)
   save_file(state_assignments)
 }
 

--- a/Rscripts/add_margins.R
+++ b/Rscripts/add_margins.R
@@ -38,6 +38,17 @@ correct_invalid_bounds <- function(state_assignments, chromosome_sizes) {
   return(state_assignments)
 }
 
+save_file <- function(data, file_path) {
+  data.table::fwrite(
+    data,
+    file = file_path,
+    quote = FALSE,
+    sep = "\t",
+    row.names = FALSE,
+    col.names = FALSE
+  )
+}
+
 main <- function(state_assignments_file, margin, chromosome_sizes_file) {
   state_assignments <- data.table::fread(
     state_assignments_file,

--- a/Rscripts/add_margins.R
+++ b/Rscripts/add_margins.R
@@ -1,10 +1,26 @@
-main <- function(state_assignments_file, margin) {
-  state_assignments <- data.table::fread(state_assignments_file)
-  state_assignments <- add_margins(state_assignments)
+process_chromosome_sizes <- function(chromosome_sizes_file) {
+  chromosome_sizes_table <- data.table::fread(
+    chromosome_sizes_file,
+    col.names = c("chromosome", "chromosome_size"),
+    colClasses = c("character", "integer")
+  )
+
+  chromosome_sizes <- chromosome_sizes_table[["chromosome_size"]]
+  names(chromosome_sizes) <- chromosome_sizes_table[["chromosome"]]
+  return(chromosome_sizes)
+}
+
 add_margins <- function(state_assignments, margin) {
   state_assignments <- state_assignments |>
     dplyr::mutate(start = start - margin, end = end + margin)
 }
+
+main <- function(state_assignments_file, margin, chromosome_sizes_file) {
+  state_assignments <- data.table::fread(
+    state_assignments_file,
+    col.names = c("chr", "start", "end", "state")
+  )
+  chromosome_sizes <- process_chromosome_sizes(chromosome_sizes_file)
   state_assignments <- add_margins(state_assignments, margin)
   save_file(state_assignments)
 }
@@ -12,5 +28,6 @@ add_margins <- function(state_assignments, margin) {
 args <- commandArgs(trailingOnly = TRUE)
 state_assignments_file <- args[[1]]
 margin <- as.numeric(args[[2]])
+chromosome_sizes_file <- args[[3]]
 
-main(state_assignments_file, margin)
+main(state_assignments_file, margin, chromosome_sizes_file)

--- a/Rscripts/add_margins.R
+++ b/Rscripts/add_margins.R
@@ -19,22 +19,21 @@ correct_invalid_bounds <- function(state_assignments, chromosome_sizes) {
   # When adding margins, some extremal intervals will end up being invalid.
   # For example, the intervals at the start of each chromosome will now span
   # into the negatives. We need to correct for such bounds.
+  state_assignments <- dplyr::mutate(
+    state_assignments,
+    start = ifelse(state < 0, 0, start)
+  )
   present_chromosomes <- unique(state_assignments[["chr"]])
   for (chromosome in present_chromosomes) {
     chromosome_size <- chromosome_sizes[[chromosome]]
-    state_assignments <- state_assignments |>
-      dplyr::mutate(
-        start = ifelse(
-          start < 0 && chr == chromosome,
-          0,
-          start
-        ),
-        end = ifelse(
-          end > chromosome_size && chr == chromosome,
-          chromosome_size,
-          end
-        )
+    state_assignments <- dplyr::mutate(
+      state_assignments,
+      end = ifelse(
+        end > chromosome_size && chr == chromosome,
+        chromosome_size,
+        end
       )
+    )
   }
   return(state_assignments)
 }

--- a/Rscripts/add_margins.R
+++ b/Rscripts/add_margins.R
@@ -49,7 +49,10 @@ save_file <- function(data, file_path) {
   )
 }
 
-main <- function(state_assignments_file, margin, chromosome_sizes_file) {
+main <- function(state_assignments_file,
+                 margin,
+                 chromosome_sizes_file,
+                 output_file_path) {
   state_assignments <- data.table::fread(
     state_assignments_file,
     col.names = c("chr", "start", "end", "state")
@@ -60,12 +63,13 @@ main <- function(state_assignments_file, margin, chromosome_sizes_file) {
     state_assignments,
     chromosome_sizes
   )
-  save_file(state_assignments)
+  save_file(state_assignments, output_file_path)
 }
 
 args <- commandArgs(trailingOnly = TRUE)
 state_assignments_file <- args[[1]]
 margin <- as.numeric(args[[2]])
 chromosome_sizes_file <- args[[3]]
+output_file_path <- args[[4]]
 
-main(state_assignments_file, margin, chromosome_sizes_file)
+main(state_assignments_file, margin, chromosome_sizes_file, output_file_path)

--- a/Rscripts/add_margins.R
+++ b/Rscripts/add_margins.R
@@ -1,0 +1,11 @@
+main <- function(state_assignments_file, margin) {
+  state_assignments <- data.table::fread(state_assignments_file)
+  state_assignments <- add_margins(state_assignments)
+  save_file(state_assignments)
+}
+
+args <- commandArgs(trailingOnly = TRUE)
+state_assignments_file <- args[[1]]
+margin <- as.numeric(args[[2]])
+
+main(state_assignments_file, margin)

--- a/Rscripts/add_margins.R
+++ b/Rscripts/add_margins.R
@@ -22,11 +22,19 @@ correct_invalid_bounds <- function(state_assignments, chromosome_sizes) {
   present_chromosomes <- unique(state_assignments[["chr"]])
   for (chromosome in present_chromosomes) {
     chromosome_size <- chromosome_sizes[[chromosome]]
-    state_assignments <- dplyr::mutate(
-      state_assignments,
-      start = ifelse(start < 0, 0, start),
-      end = ifelse(end > chromosome_size, chromosome_size, end)
-    )
+    state_assignments <- state_assignments |>
+      dplyr::mutate(
+        start = ifelse(
+          start < 0 && chr == chromosome,
+          0,
+          start
+        ),
+        end = ifelse(
+          end > chromosome_size && chr == chromosome,
+          chromosome_size,
+          end
+        )
+      )
   }
   return(state_assignments)
 }

--- a/Rscripts/create_blank_bed_file.R
+++ b/Rscripts/create_blank_bed_file.R
@@ -1,0 +1,78 @@
+process_chromosome_sizes <- function(chromosome_sizes_file) {
+  chromosome_sizes_table <- data.table::fread(
+    chromosome_sizes_file,
+    col.names = c("chromosome", "chromosome_size"),
+    colClasses = c("character", "integer")
+  )
+
+  chromosome_sizes <- chromosome_sizes_table[["chromosome_size"]]
+  names(chromosome_sizes) <- chromosome_sizes_table[["chromosome"]]
+  return(chromosome_sizes)
+}
+
+
+create_bins <- function(chromosome_name, chromosome_length, bin_size) {
+  if (!startsWith(chromosome_name, "chr")) {
+    stop("chromosome name must start with the string 'chr'")
+  }
+  bin_starts <- seq(0, chromosome_length, bin_size)
+  bins <- data.table::data.table("start" = bin_starts)
+  bins <- bins |>
+    dplyr::mutate(
+      "chr" = chromosome_name,
+      "end" = start + bin_size
+    ) |>
+    dplyr::select(chr, start, end)
+  return(bins)
+}
+
+
+save_file <- function(data, file_path) {
+  data.table::fwrite(
+    data,
+    file = file_path,
+    quote = FALSE,
+    row.names = FALSE,
+    col.names = FALSE,
+    sep = "\t"
+  )
+}
+
+
+main <- function(bin_size,
+                 state_assignments_file,
+                 chromosome_sizes_file,
+                 output_file_path) {
+  chromosome_sizes <- process_chromosome_sizes(chromosome_sizes_file)
+  state_assignments <- data.table::fread(
+    state_assignments_file,
+    col.names = c("chr", "start", "end", "state")
+  )
+  chromosome_names <- unique(state_assignments[["chr"]])
+
+  blank_bed_data_list <- lapply(chromosome_names, function(chromosome_name) {
+    chromosome_length <- chromosome_sizes[chromosome_name]
+    do.call(create_bins, c(list(
+      chromosome_name,
+      chromosome_length,
+      bin_size
+    )))
+  })
+
+  blank_bed_data <- dplyr::bind_rows(blank_bed_data_list)
+  print(head(blank_bed_data, 502))
+  save_file(blank_bed_data, output_file_path)
+}
+
+args <- commandArgs(trailingOnly = TRUE)
+bin_size <- as.numeric(args[[1]])
+state_assignments_file <- args[[2]]
+chromosome_sizes_file <- args[[3]]
+output_file_path <- args[[4]]
+
+# R converts positions that are multiples of 100000 to scientific notation.
+# This behaviour causes bedtools to crash so we prevent this behaviour from
+# ocurring.
+options(scipen = 12)
+
+main(bin_size, state_assignments_file, chromosome_sizes_file, output_file_path)

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -36,6 +36,10 @@ merge_stats_tables <- function(stats_table_one, stats_table_two) {
   return(merged_stats_table)
 }
 
+calculate_genome_size <- function(combined_assignments, bin_size) {
+  return(nrow(combined_assignments) * bin_size)
+}
+
 main <- function(combined_assignments_file, bin_size, output_file_path) {
   combined_assignments <- data.table::fread(
     combined_assignments_file,

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -1,4 +1,8 @@
 main <- function(combined_assignments_file, bin_size, output_file_path) {
+  combined_assignments <- data.table::fread(
+    combined_assignments_file,
+    colnames = c("model_one", "model_two")
+  )
   model_one_stats_table <- data.table::data.table(
     "state" = numeric(1),
     "bp_in_assignment" = numeric(1),
@@ -8,11 +12,11 @@ main <- function(combined_assignments_file, bin_size, output_file_path) {
     "bp_in_assignment" = numeric(1),
   )
   model_one_stats_table <- model_one_stats_table |>
-    fill_in_states(combined_assignments_file, 1) |>
-    add_bp_coverage(combined_assignments_file, bin_size, 1)
+    fill_in_states(combined_assignments, 1) |>
+    add_bp_coverage(combined_assignments, bin_size, 1)
   model_two_stats_table <- model_two_stats_table |>
-    fill_in_states(combined_assignments_file, 2) |>
-    add_bp_coverage(combined_assignments_file, bin_size, 2)
+    fill_in_states(combined_assignments, 2) |>
+    add_bp_coverage(combined_assignments, bin_size, 2)
   stats_table <- merge_stats_tables(
     model_one_stats_table,
     model_two_stats_table
@@ -24,7 +28,7 @@ main <- function(combined_assignments_file, bin_size, output_file_path) {
 
   stats_table <- add_bp_overlap(stats_table)
 
-  genome_size <- calculate_genome_size(combined_assignments_file, bin_size)
+  genome_size <- calculate_genome_size(combined_assignments, bin_size)
 
   fold_enrichment_matrix <- create_fold_enrichment_matrix(stats_table)
   fold_enrichment_heatmap <-

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -88,8 +88,8 @@ create_fold_enrichment_matrix <- function(stats_table) {
       names_from = state_two,
       values_from = fold_enrichment
     ) |>
-    data.table::as.data.table() |>
-    as.matrix(rownames = "state_one")
+    dplyr::select(-state_one) |>
+    as.matrix()
   return(fold_enrichment_matrix)
 }
 

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -111,7 +111,7 @@ save_matrix <- function(matrix, file_path) {
 main <- function(combined_assignments_file, bin_size, output_file_path) {
   combined_assignments <- data.table::fread(
     combined_assignments_file,
-    colnames = c("model_one", "model_two", "overlap")
+    col.names = c("model_one", "model_two", "overlap")
   )
   model_one_stats_table <-
     find_states_assigned(combined_assignments[["model_one"]]) |>

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -55,10 +55,6 @@ main <- function(combined_assignments_file, bin_size, output_file_path) {
     model_one_stats_table,
     model_two_stats_table
   )
-  colnames(stats_table) <- c(
-    "state_one", "bp_in_assignment_one",
-    "state_two", "bp_in_assignment_two"
-  )
 
   stats_table <- add_bp_overlap(stats_table)
 

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -47,7 +47,11 @@ add_bp_overlap <- function(stats_table, combined_assignments) {
       bp_overlap = sum(overlap, na.rm = TRUE),
       .groups = "drop"
     ) |>
-    data.table::as.data.table()
+    data.table::as.data.table() |>
+    dplyr::left_join(
+      stats_table,
+      by = c("state_one" = "state_one", "state_two" = "state_two")
+    )
   return(stats_table)
 }
 

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -93,6 +93,17 @@ create_fold_enrichment_matrix <- function(stats_table) {
   return(fold_enrichment_matrix)
 }
 
+save_matrix <- function(matrix, file_path) {
+  data.table::fwrite(
+    matrix,
+    file = file_path,
+    quote = FALSE,
+    row.names = FALSE,
+    col.names = TRUE,
+    sep = ","
+  )
+}
+
 main <- function(combined_assignments_file, bin_size, output_file_path) {
   combined_assignments <- data.table::fread(
     combined_assignments_file,
@@ -117,7 +128,7 @@ main <- function(combined_assignments_file, bin_size, output_file_path) {
 
   fold_enrichment_matrix <- create_fold_enrichment_matrix(stats_table)
 
-  save_matrix(fold_enrichment_matrix)
+  save_matrix(fold_enrichment_matrix, output_file_path)
 }
 
 args <- commandArgs(trailingOnly = TRUE)

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -15,10 +15,31 @@ add_bp_coverage <- function(states, state_assignments, bin_size) {
   return(stats_table)
 }
 
+merge_stats_tables <- function(stats_table_one, stats_table_two) {
+  merged_stats_table <- data.table::data.table(
+    "state_one" = integer(0),
+    "state_two" = integer(0),
+    "bp_coverage_one" = integer(0),
+    "bp_coverage_two" = integer(0)
+  )
+  for (i in seq_len(nrow(stats_table_one))) {
+    for (j in seq_len(nrow(stats_table_two))) {
+      new_row <- c(
+        "state_one" = stats_table_one[["States"]][[i]],
+        "state_two" = stats_table_two[["States"]][[j]],
+        "bp_coverage_one" = stats_table_one[["bp_coverage"]][[i]],
+        "bp_coverage_two" = stats_table_two[["bp_coverage"]][[j]]
+      )
+      merged_stats_table <- dplyr::bind_rows(merged_stats_table, new_row)
+    }
+  }
+  return(merged_stats_table)
+}
+
 main <- function(combined_assignments_file, bin_size, output_file_path) {
   combined_assignments <- data.table::fread(
     combined_assignments_file,
-    colnames = c("model_one", "model_two")
+    colnames = c("model_one", "model_two", "overlap")
   )
   model_one_stats_table <-
     find_states_assigned(combined_assignments[["model_one"]]) |>

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -81,6 +81,18 @@ add_fold_enrichment <- function(stats_table, genome_size) {
   return(stats_table)
 }
 
+create_fold_enrichment_matrix <- function(stats_table) {
+  fold_enrichment_matrix <- stats_table |>
+    dplyr::select(state_one, state_two, fold_enrichment) |>
+    tidyr::pivot_wider(
+      names_from = state_two,
+      values_from = fold_enrichment
+    ) |>
+    data.table::as.data.table() |>
+    as.matrix(rownames = "state_one")
+  return(fold_enrichment_matrix)
+}
+
 main <- function(combined_assignments_file, bin_size, output_file_path) {
   combined_assignments <- data.table::fread(
     combined_assignments_file,

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -115,10 +115,10 @@ main <- function(combined_assignments_file, bin_size, output_file_path) {
   )
   model_one_stats_table <-
     find_states_assigned(combined_assignments[["model_one"]]) |>
-    add_bp_coverage(combined_assignments, bin_size)
+    add_bp_coverage(combined_assignments[["model_one"]], bin_size)
   model_two_stats_table <-
     find_states_assigned(combined_assignments[["model_two"]]) |>
-    add_bp_coverage(combined_assignments, bin_size)
+    add_bp_coverage(combined_assignments[["model_two"]], bin_size)
   stats_table <- merge_stats_tables(
     model_one_stats_table,
     model_two_stats_table

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -1,21 +1,20 @@
+generate_stats_table <- function(combined_assignments, column) {
+  states_present <- unique(combined_assignments[[column]])
+  sorted_states <- sort(states_present)
+  stats_table <- data.table::data.table("state" = sorted_states)
+  return(stats_table)
+}
+
 main <- function(combined_assignments_file, bin_size, output_file_path) {
   combined_assignments <- data.table::fread(
     combined_assignments_file,
     colnames = c("model_one", "model_two")
   )
-  model_one_stats_table <- data.table::data.table(
-    "state" = numeric(1),
-    "bp_in_assignment" = numeric(1),
-  )
-  model_two_stats_table <- data.table::data.table(
-    "state" = numeric(1),
-    "bp_in_assignment" = numeric(1),
-  )
-  model_one_stats_table <- model_one_stats_table |>
-    fill_in_states(combined_assignments, 1) |>
+  model_one_stats_table <-
+    generate_stats_table(combined_assignments, column = "model_one") |>
     add_bp_coverage(combined_assignments, bin_size, 1)
-  model_two_stats_table <- model_two_stats_table |>
-    fill_in_states(combined_assignments, 2) |>
+  model_two_stats_table <-
+    generate_stats_table(combined_assignments, column = "model_two") |>
     add_bp_coverage(combined_assignments, bin_size, 2)
   stats_table <- merge_stats_tables(
     model_one_stats_table,

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -40,11 +40,8 @@ main <- function(combined_assignments_file, bin_size, output_file_path) {
   genome_size <- calculate_genome_size(combined_assignments, bin_size)
 
   fold_enrichment_matrix <- create_fold_enrichment_matrix(stats_table)
-  fold_enrichment_heatmap <-
-    create_fold_enrichment_heatmap(fold_enrichment_matrix)
 
   save_matrix(fold_enrichment_matrix)
-  save_heatmap(fold_enrichment_heatmap)
 }
 
 args <- commandArgs(trailingOnly = TRUE)

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -25,8 +25,8 @@ merge_stats_tables <- function(stats_table_one, stats_table_two) {
   for (i in seq_len(nrow(stats_table_one))) {
     for (j in seq_len(nrow(stats_table_two))) {
       new_row <- c(
-        "state_one" = stats_table_one[["States"]][[i]],
-        "state_two" = stats_table_two[["States"]][[j]],
+        "state_one" = stats_table_one[["states"]][[i]],
+        "state_two" = stats_table_two[["states"]][[j]],
         "bp_coverage_one" = stats_table_one[["bp_coverage"]][[i]],
         "bp_coverage_two" = stats_table_two[["bp_coverage"]][[j]]
       )

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -1,0 +1,30 @@
+main <- function(combined_assignments_file, bin_size, output_file_path) {
+  stats_table <- data.table::data.table(
+    "model_one_state" = numeric(1),
+    "model_two_state" = numeric(2),
+    "bp_in_model_one_state" = numeric(1),
+    "bp_in_model_two_state" = numeric(1),
+    "bp_in_overlap_for_state_pair" = numeric(1),
+    "fold_enrichment_for_pair" = numeric(1)
+  )
+  genome_size <- calculate_genome_size(combined_assignments_file, bin_size)
+  stats_table <- stats_table |>
+    fill_in_states() |>
+    calculate_bp_coverage(combined_assignments_file, bin_size, 1) |>
+    calculate_bp_coverage(combined_assignments_file, bin_size, 2) |>
+    calculate_overlapping_bp(combined_assignments_file, bin_size) |>
+    calculate_fold_enrichment(genome_size)
+
+  fold_enrichment_matrix <- create_fold_enrichment_matrix(stats_table)
+  fold_enrichment_heatmap <-
+    create_fold_enrichment_heatmap(fold_enrichment_matrix)
+  save_matrix(fold_enrichment_matrix)
+  save_heatmap(fold_enrichment_heatmap)
+}
+
+args <- commandArgs(trailingOnly = TRUE)
+combined_assignments_file <- args[[1]]
+bin_size <- as.numeric(args[[2]])
+output_file_path <- args[[3]]
+
+main(combined_assignments_file, bin_size, output_file_path)

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -98,7 +98,7 @@ create_fold_enrichment_matrix <- function(stats_table) {
 }
 
 save_matrix <- function(matrix, file_path) {
-  data.table::fwrite(
+  write.table(
     matrix,
     file = file_path,
     quote = FALSE,

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -5,6 +5,17 @@ generate_stats_table <- function(combined_assignments, column) {
   return(stats_table)
 }
 
+add_bp_coverage <- function(states, state_assignments) {
+  bp_coverage <- lapply(states, function(state) {
+    sum(state_assignments == state)
+  })
+  stats_table <- data.table::data.table(
+    "states" = states,
+    "bp_coverage" = bp_coverage
+  )
+  return(stats_table)
+}
+
 main <- function(combined_assignments_file, bin_size, output_file_path) {
   combined_assignments <- data.table::fread(
     combined_assignments_file,

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -36,6 +36,23 @@ merge_stats_tables <- function(stats_table_one, stats_table_two) {
   return(merged_stats_table)
 }
 
+add_bp_overlap <- function(stats_table, combined_assignments) {
+  for (row in seq_len(nrow(stats_table))) {
+    state_one <- stats_table[["state_one"]][[row]]
+    state_two <- stats_table[["state_two"]][[row]]
+    overlap <- dplyr::filter(
+      combined_assignments,
+      model_one == state_one,
+      model_two == state_two
+    ) |>
+      dplyr::select(
+        overlap
+      )
+    total_overlap <- sum(overlap)
+    stats_table[["bp_overlap"]][[row]] <- total_overlap
+  }
+}
+
 calculate_genome_size <- function(combined_assignments, bin_size) {
   return(nrow(combined_assignments) * bin_size)
 }
@@ -56,7 +73,7 @@ main <- function(combined_assignments_file, bin_size, output_file_path) {
     model_two_stats_table
   )
 
-  stats_table <- add_bp_overlap(stats_table)
+  stats_table <- add_bp_overlap(stats_table, combined_assignments)
 
   genome_size <- calculate_genome_size(combined_assignments, bin_size)
 

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -1,13 +1,12 @@
-generate_stats_table <- function(combined_assignments, column) {
-  states_present <- unique(combined_assignments[[column]])
+find_states_assigned <- function(state_assignments) {
+  states_present <- unique(state_assignments)
   sorted_states <- sort(states_present)
-  stats_table <- data.table::data.table("state" = sorted_states)
-  return(stats_table)
+  return(sorted_states)
 }
 
-add_bp_coverage <- function(states, state_assignments) {
+add_bp_coverage <- function(states, state_assignments, bin_size) {
   bp_coverage <- lapply(states, function(state) {
-    sum(state_assignments == state)
+    sum(state_assignments == state) * bin_size
   })
   stats_table <- data.table::data.table(
     "states" = states,
@@ -22,11 +21,11 @@ main <- function(combined_assignments_file, bin_size, output_file_path) {
     colnames = c("model_one", "model_two")
   )
   model_one_stats_table <-
-    generate_stats_table(combined_assignments, column = "model_one") |>
-    add_bp_coverage(combined_assignments, bin_size, 1)
+    find_states_assigned(combined_assignments[["model_one"]]) |>
+    add_bp_coverage(combined_assignments, bin_size)
   model_two_stats_table <-
-    generate_stats_table(combined_assignments, column = "model_two") |>
-    add_bp_coverage(combined_assignments, bin_size, 2)
+    find_states_assigned(combined_assignments[["model_two"]]) |>
+    add_bp_coverage(combined_assignments, bin_size)
   stats_table <- merge_stats_tables(
     model_one_stats_table,
     model_two_stats_table

--- a/Setup/example_config.txt
+++ b/Setup/example_config.txt
@@ -47,3 +47,12 @@ MODEL_ONE_STATE_ASSIGNMENTS_FILE="full/path/to/state/assignments/file"
 
 MODEL_TWO_EMISSIONS_FILE="full/path/to/emissions/file"
 MODEL_TWO_STATE_ASSIGNMENTS_FILE="full/path/to/state/assignments/file"
+
+# ---------------- #
+# ADDITIONAL FILES #
+# ---------------- #
+
+# ChromHMM comes with files in the CHROMSIZES directory that give the size of
+# each chromosome under several different genome builds. Please provide a path
+# to your desired genome build.
+CHROMOSOME_SIZES_FILE="path/to/ChromHMM/CHROMSIZES/hg38.txt"


### PR DESCRIPTION
## Description
This pull request will add a script to find the spatial similarity between two models. It also allows for there to be some margins added around any state assignments to help with jitters in chromHMM. Not sure what the margins should actually be just yet, I will probably let the user decide and give them a default selection (that is based off of the bin size).

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code is consistent in style with the rest of ChromCompare
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
