### PR TITLE
Add score combiner script

### DIFF
--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -141,7 +141,6 @@ run_spatial_similarity() {
 combine_similarity_scores() {
   emission_similarities_file=$1
   spatial_similarities_prefix=$2
-  output_file=$3
 
   spatial_similarities_files=$( \
     find "${PROCESSING_DIRECTORY}" \
@@ -155,7 +154,7 @@ combine_similarity_scores() {
     "${emission_similarities_file}" \
     "${spatial_similarities_files}" \
     "${WEIGHTS}" \
-    "${output_file}"
+    "${OUTPUT_DIRECTORY}"
 }
 
 clean_up() {
@@ -172,7 +171,7 @@ main() {
   move_log_files
 
   mkdir -p \
-    "${OUTPUT_DIRECTORY}/similarity_scores" \
+    "${OUTPUT_DIRECTORY}" \
     "${PROCESSING_DIRECTORY}"
 
   emission_similarities_file="${PROCESSING_DIRECTORY}/similarity_scores/emission_similarity.txt"
@@ -200,11 +199,9 @@ main() {
     "${PROCESSING_DIRECTORY}/state_assignments_model_two.bed"
     "${state_assignments_similarity_file_prefix}"
 
-  combined_similarity_score_file="${OUTPUT_DIRECTORY}/similarity_scores.txt"
   combine_similarity_scores \
     "${emission_similarities_file}" \
-    "${state_assignments_similarity_file_prefix}" \
-    "${combined_similarity_score_file}"
+    "${state_assignments_similarity_file_prefix}"
 
   if [[ "${DEBUG_MODE}" -eq 1 ]]; then
     clean_up \

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -139,19 +139,24 @@ run_spatial_similarity() {
       "${RSCRIPT_DIRECTORY}/spatial_similarity.R" \
       "${PROCESSING_DIRECTORY}/state_assignment_overlap_margin_${margin}.bed" \
       "${bin_size}" \
-      "${output_file_prefix}${margin}.txt"
+      "${PROCESSING_DIRECTORY}/${output_file_prefix}${margin}.txt"
   done
 }
 
 combine_similarity_scores() {
   emission_similarities_file=$1
-  state_assignments_similarities_file=$2
+  spatial_similarities_prefix=$2
   output_file=$3
+
+  spatial_similarities_files=$( \
+    find "${PROCESSING_DIRECTORY}" \
+    -name "${spatial_similarities_prefix}*.txt" \
+  )
   
   Rscript \
     "${RSCRIPT_DIRECTORY}/combine_similiarity_scores.R" \
     "${emission_similarities_file}" \
-    "${state_assignments_similarities_file}" \
+    "${spatial_similarities_files}" \
     "${output_file}"
 }
 
@@ -205,6 +210,7 @@ main() {
   combined_similarity_score_file="${OUTPUT_DIRECTORY}/similarity_scores.txt"
   combine_similarity_scores \
     "${emission_similarities_file}" \
+    "${state_assignments_similarity_file_prefix}" \
     "${combined_similarity_score_file}"
 
   if [[ "${DEBUG_MODE}" -eq 1 ]]; then

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -67,15 +67,13 @@ run_emission_similarity() {
 
 create_blank_bins() {
   state_assignment_file_one=$1
-  bin_size=$2
-  chromosome_sizes_file=$3
-  output_file=$4
+  output_file=$2
 
   Rscript \
     "${RSCRIPT_DIRECTORY}/create_blank_bed_file" \
-    "${bin_size}" \
+    "${BIN_SIZE}" \
     "${state_assignment_file_one}" \
-    "${chromosome_sizes_file}" \
+    "${CHROMOSOME_SIZES_FILE}" \
     "${PROCESSING_DIRECTORY}/blank_bins.bed"
 
   # Sorting required for later bedtools intersect. The output of the Rscript is
@@ -109,10 +107,9 @@ convert_state_assignments() {
 run_spatial_similarity() {
   state_assignment_file_one=$1
   state_assignment_file_two=$2
-  bin_size=$3
-  output_file_prefix=$4
+  output_file_prefix=$3
 
-  shift 4
+  shift 3
   margins=("$@")
   for margin in "${margins[@]}"; do
     Rscript \
@@ -138,7 +135,7 @@ run_spatial_similarity() {
     Rscript \
       "${RSCRIPT_DIRECTORY}/spatial_similarity.R" \
       "${PROCESSING_DIRECTORY}/state_assignment_overlap_margin_${margin}.bed" \
-      "${bin_size}" \
+      "${BIN_SIZE}" \
       "${PROCESSING_DIRECTORY}/${output_file_prefix}${margin}.txt"
   done
 }
@@ -185,8 +182,6 @@ main() {
 
   create_blank_bins \
     "${MODEL_ONE_STATE_ASSIGNMENTS_FILE}" \
-    "${BIN_SIZE}" \
-    "${CHROMOSOME_SIZES_FILE}" \
     "${PROCESSING_DIRECTORY}/sorted_blank_bins.bed"
 
   convert_state_assignments \
@@ -203,7 +198,6 @@ main() {
   run_spatial_similarity \
     "${PROCESSING_DIRECTORY}/state_assignments_model_one.bed"
     "${PROCESSING_DIRECTORY}/state_assignments_model_two.bed"
-    "${BIN_SIZE}" \
     "${state_assignments_similarity_file_prefix}" \
     "${margins[@]}"
 

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -109,9 +109,7 @@ run_spatial_similarity() {
   state_assignment_file_two=$2
   output_file_prefix=$3
 
-  shift 3
-  margins=("$@")
-  for margin in "${margins[@]}"; do
+  for margin in "${MARGINS[@]}"; do
     Rscript \
       "${RSCRIPT_DIRECTORY}/add_margins.R" \
       "${state_assignment_file_one}" \
@@ -147,13 +145,16 @@ combine_similarity_scores() {
 
   spatial_similarities_files=$( \
     find "${PROCESSING_DIRECTORY}" \
-    -name "${spatial_similarities_prefix}*.txt" \
+    -name "${spatial_similarities_prefix}*.txt" | \
+    tr '\n' ',' | \
+    sed 's/,$//'
   )
   
   Rscript \
     "${RSCRIPT_DIRECTORY}/combine_similiarity_scores.R" \
     "${emission_similarities_file}" \
     "${spatial_similarities_files}" \
+    "${WEIGHTS}" \
     "${output_file}"
 }
 
@@ -193,13 +194,11 @@ main() {
     "${MODEL_TWO_STATE_ASSIGNMENTS_FILE}" \
     "${PROCESSING_DIRECTORY}/state_assignments_model_two.bed"
 
-  margins=(0 "${BIN_SIZE}" $((BIN_SIZE * 10)))
   state_assignments_similarity_file_prefix="${PROCESSING_DIRECTORY}/similarity_scores/state_assignment_similarity_margin_"
   run_spatial_similarity \
     "${PROCESSING_DIRECTORY}/state_assignments_model_one.bed"
     "${PROCESSING_DIRECTORY}/state_assignments_model_two.bed"
-    "${state_assignments_similarity_file_prefix}" \
-    "${margins[@]}"
+    "${state_assignments_similarity_file_prefix}"
 
   combined_similarity_score_file="${OUTPUT_DIRECTORY}/similarity_scores.txt"
   combine_similarity_scores \

--- a/Rscripts/combine_similarity_scores.R
+++ b/Rscripts/combine_similarity_scores.R
@@ -64,7 +64,7 @@ get_likely_state_pairs <- function(similarity_scores) {
   )
 
   # Makes the resultant matrix in a more readable fashion
-  likely_state_pairs <- t(likely_state_pairs)
+  likely_state_pairs <- t(likely_state_pairs)[, c(2, 1)]
   colnames(likely_state_pairs) <- c("model_one_state", "model_two_state")
 
   return(likely_state_pairs)

--- a/Rscripts/combine_similarity_scores.R
+++ b/Rscripts/combine_similarity_scores.R
@@ -8,17 +8,50 @@ read_matrix <- function(file_path) {
   return(matrix)
 }
 
+calculate_max_fold_enrichment <- function(spatial_similarities) {
+  max_fold_enrichments <- vapply(
+    spatial_similarities,
+    max,
+    numeric(1)
+  )
+  return(max(max_fold_enrichments))
+}
+
+calculate_emission_score <- function(distance,
+                                     max_distance,
+                                     max_fold_enrichment) {
+  max_fold_enrichment * (1 - distance / max_distance)
+}
+
+generate_emission_similarities <- function(emission_similarities,
+                                           max_fold_enrichment) {
+  max_euclidean_distance <- max(emission_similarities)
+  emission_similarity_scores <- apply(
+    emission_similarities,
+    c(1, 2),
+    calculate_emission_score,
+    max_euclidean_distance,
+    max_fold_enrichment
+  )
+  return(emission_similarity_scores)
+}
+
 
 main <- function(emission_similarities_file,
                  spatial_similarities_file_list,
                  weights,
                  output_file_path) {
-  emission_similarities <- read_matrix(emission_similarities_file)
+  emission_distances <- read_matrix(emission_similarities_file)
   spatial_similarities <- lapply(
     spatial_similarities_file_list,
     function(file_path) {
       read_matrix(file_path)
     }
+  )
+  max_fold_enrichment <- calculate_max_fold_enrichment(spatial_similarities)
+  emission_similarities <- generate_emission_similarities(
+    emission_distances,
+    max_fold_enrichment
   )
   all_similarity_matrices <- append(
     emission_similarities,

--- a/Rscripts/combine_similarity_scores.R
+++ b/Rscripts/combine_similarity_scores.R
@@ -1,0 +1,35 @@
+main <- function(emission_similarities_file,
+                 spatial_similarities_file_list,
+                 weights,
+                 output_file_path) {
+  emission_similarities <- read_matrix(emission_similarities_file)
+  spatial_similarities <- lapply(
+    spatial_similarities_file_list,
+    function(file_path) {
+      read_matrix(file_path)
+    }
+  )
+  all_similarity_matrices <- append(
+    emission_similarities,
+    spatial_similarities
+  )
+  combined_matrix <- combine_similarity_matrices(
+    all_similarity_matrices,
+    weights
+  )
+  print_likely_state_pairs(combined_matrix)
+  save_matrix(combined_matrix)
+}
+
+args <- commandArgs(trailingOnly = TRUE)
+emission_similarities_file <- args[[1]]
+spatial_similarities_file_list <- unlist(strsplit(args[[2]], ","))
+weights <- as.numeric(unlist(strsplit(args[[3]], ",")))
+output_file <- args[[4]]
+
+main(
+  emission_similarities_file,
+  spatial_similarities_file_list,
+  weights,
+  output_file_path
+)

--- a/Rscripts/combine_similarity_scores.R
+++ b/Rscripts/combine_similarity_scores.R
@@ -70,12 +70,12 @@ get_likely_state_pairs <- function(similarity_scores) {
   return(likely_state_pairs)
 }
 
-save_file <- function(data, output_file_path) {
+save_file <- function(data, output_file_path, header) {
   write.table(
     data,
     file = output_file_path,
     sep = ",",
-    col.names = TRUE,
+    col.names = header,
     row.names = FALSE,
     quote = FALSE
   )
@@ -108,11 +108,13 @@ main <- function(emission_similarities_file,
   likely_state_pairs <- get_likely_state_pairs(combined_matrix)
   save_file(
     likely_state_pairs,
-    file.path(output_file_path, "likely_state_pairs.txt")
+    file.path(output_file_path, "likely_state_pairs.txt"),
+    header = TRUE
   )
   save_file(
     combined_matrix,
-    file.path(output_file_path, "similarity_scores.txt")
+    file.path(output_file_path, "similarity_scores.txt"),
+    header = FALSE
   )
 }
 

--- a/Rscripts/combine_similarity_scores.R
+++ b/Rscripts/combine_similarity_scores.R
@@ -70,10 +70,9 @@ get_likely_state_pairs <- function(similarity_scores) {
   return(likely_state_pairs)
 }
 
-save_likely_state_pairs <- function(likely_state_pairs, output_file_path) {
-  output_file_path <- file.path(output_file_path, "likely_state_pairs.txt")
+save_file <- function(data, output_file_path) {
   write.table(
-    likely_state_pairs,
+    data,
     file = output_file_path,
     sep = ",",
     col.names = TRUE,
@@ -107,15 +106,21 @@ main <- function(emission_similarities_file,
     weights
   )
   likely_state_pairs <- get_likely_state_pairs(combined_matrix)
-  save_likely_state_pairs(likely_state_pairs)
-  save_matrix(combined_matrix)
+  save_file(
+    likely_state_pairs,
+    file.path(output_file_path, "likely_state_pairs.txt")
+  )
+  save_file(
+    combined_matrix,
+    file.path(output_file_path, "similarity_scores.txt")
+  )
 }
 
 args <- commandArgs(trailingOnly = TRUE)
 emission_similarities_file <- args[[1]]
 spatial_similarities_files <- unlist(strsplit(args[[2]], ","))
 weights <- as.numeric(unlist(strsplit(args[[3]], ",")))
-output_file <- args[[4]]
+output_file_path <- args[[4]]
 
 main(
   emission_similarities_file,

--- a/Rscripts/combine_similarity_scores.R
+++ b/Rscripts/combine_similarity_scores.R
@@ -54,6 +54,34 @@ combine_similarity_matrices <- function(matrix_list, weights) {
   return(combined_matrix)
 }
 
+get_likely_state_pairs <- function(similarity_scores) {
+  likely_state_pairs <- apply(
+    similarity_scores,
+    2,
+    function(row) {
+      which(similarity_scores == max(row), arr.ind = TRUE)
+    }
+  )
+
+  # Makes the resultant matrix in a more readable fashion
+  likely_state_pairs <- t(likely_state_pairs)
+  colnames(likely_state_pairs) <- c("model_one_state", "model_two_state")
+
+  return(likely_state_pairs)
+}
+
+save_likely_state_pairs <- function(likely_state_pairs, output_file_path) {
+  output_file_path <- file.path(output_file_path, "likely_state_pairs.txt")
+  write.table(
+    likely_state_pairs,
+    file = output_file_path,
+    sep = ",",
+    col.names = TRUE,
+    row.names = FALSE,
+    quote = FALSE
+  )
+}
+
 main <- function(emission_similarities_file,
                  spatial_similarities_files,
                  weights,
@@ -78,7 +106,8 @@ main <- function(emission_similarities_file,
     all_similarity_matrices,
     weights
   )
-  print_likely_state_pairs(combined_matrix)
+  likely_state_pairs <- get_likely_state_pairs(combined_matrix)
+  save_likely_state_pairs(likely_state_pairs)
   save_matrix(combined_matrix)
 }
 

--- a/Rscripts/combine_similarity_scores.R
+++ b/Rscripts/combine_similarity_scores.R
@@ -25,6 +25,13 @@ calculate_emission_score <- function(distance,
 
 generate_emission_similarities <- function(emission_similarities,
                                            max_fold_enrichment) {
+  # The emissions matrix read in contains Euclidean distances. Here, a smaller
+  # number signifies higher similarity. However, with the spatial
+  # similarities, a higher fold enrichment signifies higher similarity. In
+  # order to make these two types of similarity comparable, a basic scalar
+  # transform is used. This ensures that low Euclidean distances are converted
+  # to scores comparable to the highest spatial similarity scores, whilst high
+  # Euclidean distances are converted to values close to zero.
   max_euclidean_distance <- max(emission_similarities)
   emission_similarity_scores <- apply(
     emission_similarities,

--- a/Rscripts/combine_similarity_scores.R
+++ b/Rscripts/combine_similarity_scores.R
@@ -55,12 +55,12 @@ combine_similarity_matrices <- function(matrix_list, weights) {
 }
 
 main <- function(emission_similarities_file,
-                 spatial_similarities_file_list,
+                 spatial_similarities_files,
                  weights,
                  output_file_path) {
   emission_distances <- read_matrix(emission_similarities_file)
   spatial_similarities <- lapply(
-    spatial_similarities_file_list,
+    spatial_similarities_files,
     function(file_path) {
       read_matrix(file_path)
     }
@@ -84,13 +84,13 @@ main <- function(emission_similarities_file,
 
 args <- commandArgs(trailingOnly = TRUE)
 emission_similarities_file <- args[[1]]
-spatial_similarities_file_list <- unlist(strsplit(args[[2]], ","))
+spatial_similarities_files <- unlist(strsplit(args[[2]], ","))
 weights <- as.numeric(unlist(strsplit(args[[3]], ",")))
 output_file <- args[[4]]
 
 main(
   emission_similarities_file,
-  spatial_similarities_file_list,
+  spatial_similarities_files,
   weights,
   output_file_path
 )

--- a/Rscripts/combine_similarity_scores.R
+++ b/Rscripts/combine_similarity_scores.R
@@ -1,3 +1,14 @@
+read_matrix <- function(file_path) {
+  matrix <- data.table::fread(
+    file_path,
+    sep = ",",
+    header = TRUE
+  )
+  matrix <- as.matrix(matrix, rownames = seq_len(nrow(matrix)))
+  return(matrix)
+}
+
+
 main <- function(emission_similarities_file,
                  spatial_similarities_file_list,
                  weights,

--- a/Rscripts/combine_similarity_scores.R
+++ b/Rscripts/combine_similarity_scores.R
@@ -43,6 +43,16 @@ generate_emission_similarities <- function(emission_similarities,
   return(emission_similarity_scores)
 }
 
+combine_similarity_matrices <- function(matrix_list, weights) {
+  stopifnot(length(matrix_list) == length(weights))
+
+  # Faster to do this than initialise matrix with proper size and names
+  combined_matrix <- matrix_list[[1]] * 0
+  for (i in seq_along(matrix_list)) {
+    combined_matrix <- combined_matrix + weights[[i]] * matrix_list[[i]]
+  }
+  return(combined_matrix)
+}
 
 main <- function(emission_similarities_file,
                  spatial_similarities_file_list,

--- a/Rscripts/combine_similarity_scores.R
+++ b/Rscripts/combine_similarity_scores.R
@@ -98,7 +98,7 @@ main <- function(emission_similarities_file,
     max_fold_enrichment
   )
   all_similarity_matrices <- append(
-    emission_similarities,
+    list(emission_similarities),
     spatial_similarities
   )
   combined_matrix <- combine_similarity_matrices(

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -89,10 +89,10 @@ create_fold_enrichment_matrix <- function(stats_table) {
   fold_enrichment_matrix <- stats_table |>
     dplyr::select(state_one, state_two, fold_enrichment) |>
     tidyr::pivot_wider(
-      names_from = state_two,
+      names_from = state_one,
       values_from = fold_enrichment
     ) |>
-    dplyr::select(-state_one) |>
+    dplyr::select(-state_two) |>
     as.matrix()
   return(fold_enrichment_matrix)
 }

--- a/Setup/example_config.txt
+++ b/Setup/example_config.txt
@@ -35,6 +35,19 @@ OUTPUT_DIRECTORY="path/to/outputs"
 # minimum bin size of the two models.
 BIN_SIZE=200
 
+# To account for jitters and inaccuracies in ChromHMM, you can add a margin #
+around each state assignment to assist in showing that two states are spatially
+# similar between two models. The default is arbitrary and based off of a bin #
+size of 200. If your bin size is signficantly different, I'd recommend changing
+this. Set this to (0) if you don't want to factor in margins.
+MARGINS=(0 "${BIN_SIZE}" $((BIN_SIZE * 10)))
+
+# To give certain similarity metrics more weighting in the final calculation,
+# change this variable. Provide a comma separated list where the first value is
+# the weighting for emission parameter similarity and the remaining align with
+# the spatial similarities obtained for each margin given above.
+WEIGHTS="0.65,0.2,0.1,0.05"
+
 # ----------- #
 # MODEL FILES #
 # ----------- #


### PR DESCRIPTION
## Description
This pull request will add an R script that combines the similarity scores obtained for the emission parameters and the spatial similarity score (for each margin used). This script needs to convert the emission similarity matrix into one that is comparable to the spatial similarity scores. It needs to do this as distances that are larger signify less similarity, but for fold enrichment (which is used in the spatial similarity matrix) a larger value signifies more similarity.

I make the following transform:

$$max_fold_enrichment * (1 - distance / max_distance)$$

For each distance in the emission similarity matrix. This way, smaller values become larger (and vice versa) whilst keeping the scale roughly equivalent to that of the scale for fold enrichment values. The fact that weights also exist means I can easily nullify this scale equivalency if I see fit later on.

This PR closed #7.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code is consistent in style with the rest of ChromCompare
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
