### PR TITLE
Add config checker

### DIFF
--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -29,8 +29,16 @@ MESSAGE
 
 check_config_file() {
   config_file_location=$1
+  script_location=$(\
+    scontrol show job "${SLURM_JOB_ID}" | \
+    grep "Command" | \
+    awk '{print $1}' | \
+    awk 'BEGIN {FS="="} {print $2}' \
+  )
+    cd "$(dirname "${script_location}")" || exit 1
+    cd .. || exit 1
   python \
-    "${PYTHON_DIRECTORY}/check_config_file.py" \
+    "Python_Scripts/check_config_file.py" \
     "${config_file_location}"
 }
 

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -218,4 +218,8 @@ main() {
 }
 
 if [[ $# -ne 1 ]]; then usage; fi
+if [[ -z "${SLURM_JOB_ID}" ]]; then
+  echo "You must run this script under SLURM using sbatch."
+  exit 1
+fi
 main "$1"

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -40,6 +40,10 @@ check_config_file() {
   python \
     "Python_Scripts/check_config_file.py" \
     "${config_file_location}"
+  if [[ $? -eq 1 ]]; then
+    echo "ERROR: malformed config file detected."
+    exit 1
+  fi
 }
 
 

--- a/JobSubmission/ChromCompare.sh
+++ b/JobSubmission/ChromCompare.sh
@@ -186,7 +186,7 @@ main() {
     "${OUTPUT_DIRECTORY}" \
     "${PROCESSING_DIRECTORY}"
 
-  emission_similarities_file="${PROCESSING_DIRECTORY}/similarity_scores/emission_similarity.txt"
+  emission_similarities_file="${PROCESSING_DIRECTORY}/emission_similarity.txt"
   run_emission_similarity \
     "${MODEL_ONE_EMISSIONS_FILE}" \
     "${MODEL_TWO_EMISSIONS_FILE}" \
@@ -205,7 +205,7 @@ main() {
     "${MODEL_TWO_STATE_ASSIGNMENTS_FILE}" \
     "${PROCESSING_DIRECTORY}/state_assignments_model_two.bed"
 
-  state_assignments_similarity_file_prefix="${PROCESSING_DIRECTORY}/similarity_scores/state_assignment_similarity_margin_"
+  state_assignments_similarity_file_prefix="${PROCESSING_DIRECTORY}/state_assignment_similarity_margin_"
   run_spatial_similarity \
     "${PROCESSING_DIRECTORY}/state_assignments_model_one.bed"
     "${PROCESSING_DIRECTORY}/state_assignments_model_two.bed"

--- a/Python_Scripts/check_config_file.py
+++ b/Python_Scripts/check_config_file.py
@@ -106,6 +106,22 @@ def validate_variable_values(config_variables: dict) -> bool:
     return True
 
 
+def validate_weight_margin_compatability(config_variables: dict) -> None:
+    margins = config_variables["MARGINS"].strip("()").split()
+    weights = config_variables["WEIGHTS"].split(",")
+    correct_number_of_weights = len(margins) + 1
+    if correct_number_of_weights != len(weights):
+        print(
+            "The number of weights in WEIGHTS must be:",
+            correct_number_of_weights,
+            "\n",
+            "\bOne for the emission similarity matrix and then one for each",
+            "spatial similarity matrix",
+            "(which corresponds to the size of the MARGINS array)"
+        )
+        sys.exit(1)
+
+
 def is_repo_directory_correct(repo_directory: str) -> bool:
     repo_directory = Path(repo_directory)
     anchor_file = repo_directory / ".gitignore"
@@ -153,6 +169,7 @@ if __name__ == "__main__":
     validate_variable_existence(config_variables)
     if not validate_variable_values(config_variables):
         sys.exit(1)
+    validate_weight_margin_compatability(config_variables)
     if not validate_file_paths(config_variables):
         sys.exit(1)
     sys.exit(0)

--- a/Python_Scripts/check_config_file.py
+++ b/Python_Scripts/check_config_file.py
@@ -74,7 +74,7 @@ def is_positive_integer(x: str) -> bool:
 
 
 def is_bash_array(x: str) -> bool:
-    pattern = r'^\((\$?\{?\w+\}?\s*)+\)$'
+    pattern = r'^\((\d+\s*)+\)$'
     return bool(re.match(pattern, x))
 
 

--- a/Python_Scripts/check_config_file.py
+++ b/Python_Scripts/check_config_file.py
@@ -1,0 +1,15 @@
+import argparse
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="ChromCompare config file checker",
+        description="Checks whether config file for ChromCompare is valid."
+    )
+    parser.add_argument('file_path')
+    args = parser.parse_args()
+    check_eol_type(args.file_path)
+    config_variables = get_config_variables(args.file_path)
+    check_types(config_variables)
+    check_file_paths(config_variables)
+    check_number_of_weights(config_variables)
+    print("Config file is valid")

--- a/Python_Scripts/check_config_file.py
+++ b/Python_Scripts/check_config_file.py
@@ -111,7 +111,7 @@ def is_repo_directory_correct(repo_directory: str) -> bool:
     anchor_file = repo_directory / ".gitignore"
     if not anchor_file.is_file():
         print(
-            "The path given for REPO_DIRECTORY, is incorrect."
+            "The path given for REPO_DIRECTORY, is incorrect. "
             f"Please ensure that {repo_directory} points to this repository."
         )
         return False
@@ -134,7 +134,7 @@ def validate_file_paths(config_variables: dict) -> bool:
         file_path = config_variables[variable]
         if not Path(file_path).is_file():
             print(
-                f"The path given for {variable} doesn't exist",
+                f"The path given for {variable} doesn't exist.",
                 f"Please check this path: {file_path}"
             )
             paths_valid = False

--- a/Python_Scripts/check_config_file.py
+++ b/Python_Scripts/check_config_file.py
@@ -45,6 +45,7 @@ def validate_variable_existence(config_variables: dict) -> None:
         "REPO_DIRECTORY",
         "RSCRIPT_DIRECTORY",
         "OUTPUT_DIRECTORY",
+        "PROCESSING_DIRECTORY",
         "BIN_SIZE",
         "MARGINS",
         "WEIGHTS",

--- a/Python_Scripts/check_config_file.py
+++ b/Python_Scripts/check_config_file.py
@@ -1,4 +1,25 @@
 import argparse
+import sys
+
+
+def validate_eol_format(file_path: str) -> None:
+    try:
+        with open(file_path, "rb") as config_file:
+            content: bytes = config_file.read()
+    except IOError:
+        print(
+            "Could not read file",
+            file_path,
+            "Please ensure that this file exists and has read permissions."
+        )
+        sys.exit(1)
+    if b'\r' in content:
+        print(
+            "Carriage return character found in file.",
+            "Please ensure that config file uses Linux EOL characters only."
+        )
+        sys.exit(1)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -7,7 +28,7 @@ if __name__ == "__main__":
     )
     parser.add_argument('file_path')
     args = parser.parse_args()
-    check_eol_type(args.file_path)
+    validate_eol_format(args.file_path)
     config_variables = get_config_variables(args.file_path)
     check_types(config_variables)
     check_file_paths(config_variables)

--- a/Python_Scripts/check_config_file.py
+++ b/Python_Scripts/check_config_file.py
@@ -30,6 +30,9 @@ def get_config_variables(file_path: str) -> dict:
                 continue
             variable, value = line.split("=", 1)
             value = value.strip('"')
+            if value == "":
+                print(f"No value was given for {variable}.")
+                sys.exit(1)
             config_variables[variable] = value
     return config_variables
 

--- a/Python_Scripts/check_config_file.py
+++ b/Python_Scripts/check_config_file.py
@@ -106,6 +106,41 @@ def validate_variable_values(config_variables: dict) -> bool:
     return True
 
 
+def is_repo_directory_correct(repo_directory: str) -> bool:
+    repo_directory = Path(repo_directory)
+    anchor_file = repo_directory / ".gitignore"
+    if not anchor_file.is_file():
+        print(
+            "The path given for REPO_DIRECTORY, is incorrect."
+            f"Please ensure that {repo_directory} points to this repository."
+        )
+        return False
+    return True
+
+
+def validate_file_paths(config_variables: dict) -> bool:
+    paths_valid = True
+    if not is_repo_directory_correct(config_variables["REPO_DIRECTORY"]):
+        paths_valid = False
+
+    file_path_variables = [
+        "MODEL_ONE_EMISSIONS_FILE",
+        "MODEL_ONE_STATE_ASSIGNMENTS_FILE",
+        "MODEL_TWO_EMISSIONS_FILE",
+        "MODEL_TWO_STATE_ASSIGNMENTS_FILE",
+        "CHROMOSOME_SIZES_FILE"
+    ]
+    for variable in file_path_variables:
+        file_path = config_variables[variable]
+        if not Path(file_path).is_file():
+            print(
+                f"The path given for {variable} doesn't exist",
+                f"Please check this path: {file_path}"
+            )
+            paths_valid = False
+    return paths_valid
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="ChromCompare config file checker",
@@ -117,5 +152,7 @@ if __name__ == "__main__":
     config_variables = get_config_variables(args.file_path)
     validate_variable_existence(config_variables)
     if not validate_variable_values(config_variables):
+        sys.exit(1)
+    if not validate_file_paths(config_variables):
         sys.exit(1)
     sys.exit(0)

--- a/Python_Scripts/check_config_file.py
+++ b/Python_Scripts/check_config_file.py
@@ -118,5 +118,4 @@ if __name__ == "__main__":
     validate_variable_existence(config_variables)
     if not validate_variable_values(config_variables):
         sys.exit(1)
-    check_number_of_weights(config_variables)
-    print("Config file is valid")
+    sys.exit(0)

--- a/Python_Scripts/check_config_file.py
+++ b/Python_Scripts/check_config_file.py
@@ -37,6 +37,33 @@ def get_config_variables(file_path: str) -> dict:
     return config_variables
 
 
+def validate_variable_existence(config_variables: dict) -> None:
+    expected_variables = [
+        "DEBUG_MODE",
+        "REPO_DIRECTORY",
+        "RSCRIPT_DIRECTORY",
+        "OUTPUT_DIRECTORY",
+        "BIN_SIZE",
+        "MARGINS",
+        "WEIGHTS",
+        "MODEL_ONE_EMISSIONS_FILE",
+        "MODEL_ONE_STATE_ASSIGNMENTS_FILE",
+        "MODEL_TWO_EMISSIONS_FILE",
+        "MODEL_TWO_STATE_ASSIGNMENTS_FILE",
+        "CHROMOSOME_SIZES_FILE"
+    ]
+    for variable in expected_variables:
+        variable_missing = False
+        if variable not in config_variables:
+            print(
+                f"{variable} is missing from config file.",
+                "Please check the example config for what is required."
+            )
+            variable_missing = True
+        if variable_missing:
+            sys.exit(1)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="ChromCompare config file checker",
@@ -46,6 +73,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     validate_eol_format(args.file_path)
     config_variables = get_config_variables(args.file_path)
+    validate_variable_existence(config_variables)
     check_types(config_variables)
     check_file_paths(config_variables)
     check_number_of_weights(config_variables)

--- a/Python_Scripts/check_config_file.py
+++ b/Python_Scripts/check_config_file.py
@@ -21,6 +21,19 @@ def validate_eol_format(file_path: str) -> None:
         sys.exit(1)
 
 
+def get_config_variables(file_path: str) -> dict:
+    config_variables: dict = {}
+    with open(file_path, "r") as config_file:
+        for line in config_file:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            variable, value = line.split("=", 1)
+            value = value.strip('"')
+            config_variables[variable] = value
+    return config_variables
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="ChromCompare config file checker",

--- a/Setup/example_config.txt
+++ b/Setup/example_config.txt
@@ -19,7 +19,6 @@ DEBUG_MODE=0
 # ----------- #
 
 REPO_DIRECTORY="full/path/to/root/of/this/repo"
-PYTHON_DIRECTORY="${REPO_DIRECTORY}/Python_Scripts"
 RSCRIPT_DIRECTORY="${REPO_DIRECTORY}/Rscripts"
 
 # The similarity matrices (output of the pipeline) will be saved here

--- a/Setup/example_config.txt
+++ b/Setup/example_config.txt
@@ -40,7 +40,7 @@ BIN_SIZE=200
 # off of a bin   size of 200. If your bin size is signficantly different, I'd 
 # recommend changing  this. Set this to (0) if you don't want to factor in 
 # margins.
-MARGINS=(0 "${BIN_SIZE}" $((BIN_SIZE * 10)))
+MARGINS=(0 200 400)
 
 # To give certain similarity metrics more weighting in the final calculation,
 # change this variable. Provide a comma separated list where the first value is

--- a/Setup/example_config.txt
+++ b/Setup/example_config.txt
@@ -35,11 +35,12 @@ OUTPUT_DIRECTORY="path/to/outputs"
 # minimum bin size of the two models.
 BIN_SIZE=200
 
-# To account for jitters and inaccuracies in ChromHMM, you can add a margin #
-around each state assignment to assist in showing that two states are spatially
-# similar between two models. The default is arbitrary and based off of a bin #
-size of 200. If your bin size is signficantly different, I'd recommend changing
-this. Set this to (0) if you don't want to factor in margins.
+# To account for jitters and inaccuracies in ChromHMM, you can add a margin  
+# around each state assignment to assist in showing that two states are 
+# spatially  similar between two models. The default is arbitrary and based 
+# off of a bin   size of 200. If your bin size is signficantly different, I'd 
+# recommend changing  this. Set this to (0) if you don't want to factor in 
+# margins.
 MARGINS=(0 "${BIN_SIZE}" $((BIN_SIZE * 10)))
 
 # To give certain similarity metrics more weighting in the final calculation,

--- a/Setup/example_config.txt
+++ b/Setup/example_config.txt
@@ -24,6 +24,10 @@ RSCRIPT_DIRECTORY="${REPO_DIRECTORY}/Rscripts"
 # The similarity matrices (output of the pipeline) will be saved here
 OUTPUT_DIRECTORY="path/to/outputs"
 
+# Intermediate files will be sent here.
+# If you are using DEBUG_MODE, it is recommended you change this.
+PROCESSING_DIRECTORY="/tmp"
+
 # ---------- #
 # PARAMETERS #
 # ---------- #


### PR DESCRIPTION
## Description
This pull request will add a python file that does its best to check the config file for being malformed. This has its shortcomings. The problem came with variables that are defined in terms of others. I can't really think of a solution that isn't completely disgusting (and works in all edge cases). As such I have slightly adjusted the config file to no longer use variables in variables (where it is required).

I also realised that `PROCESSING_DIRECTORY` was not previously defined in the config file example, so I added that too.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code is consistent in style with the rest of ChromCompare
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
