### PR TITLE
Refactor IO operations

### DIFF
--- a/Rscripts/IO.R
+++ b/Rscripts/IO.R
@@ -1,0 +1,29 @@
+read_as_matrix <- function(file_path) {
+  matrix <- data.table::fread(
+    file_path,
+    sep = ",",
+    header = TRUE
+  )
+  matrix <- as.matrix(matrix, rownames = seq_len(nrow(matrix)))
+  return(matrix)
+}
+
+read_as_data_table <- function(file_path) {
+  data <- data.table::fread(
+    file_path,
+    sep = ",",
+    header = TRUE
+  )
+  return(data)
+}
+
+save_file <- function(data, file_path, header = TRUE, sep = ",") {
+  write.table(
+    data,
+    file = file_path,
+    sep = sep,
+    col.names = header,
+    row.names = FALSE,
+    quote = FALSE
+  )
+}

--- a/Rscripts/add_margins.R
+++ b/Rscripts/add_margins.R
@@ -38,17 +38,6 @@ correct_invalid_bounds <- function(state_assignments, chromosome_sizes) {
   return(state_assignments)
 }
 
-save_file <- function(data, file_path) {
-  data.table::fwrite(
-    data,
-    file = file_path,
-    quote = FALSE,
-    sep = "\t",
-    row.names = FALSE,
-    col.names = FALSE
-  )
-}
-
 main <- function(state_assignments_file,
                  margin,
                  chromosome_sizes_file,
@@ -63,7 +52,7 @@ main <- function(state_assignments_file,
     state_assignments,
     chromosome_sizes
   )
-  save_file(state_assignments, output_file_path)
+  save_file(state_assignments, output_file_path, header = FALSE, sep = "\t")
 }
 
 args <- commandArgs(trailingOnly = TRUE)
@@ -73,4 +62,5 @@ chromosome_sizes_file <- args[[3]]
 output_file_path <- args[[4]]
 
 options(scipen = 12)
+source("IO.R")
 main(state_assignments_file, margin, chromosome_sizes_file, output_file_path)

--- a/Rscripts/combine_similarity_scores.R
+++ b/Rscripts/combine_similarity_scores.R
@@ -1,13 +1,3 @@
-read_matrix <- function(file_path) {
-  matrix <- data.table::fread(
-    file_path,
-    sep = ",",
-    header = TRUE
-  )
-  matrix <- as.matrix(matrix, rownames = seq_len(nrow(matrix)))
-  return(matrix)
-}
-
 calculate_max_fold_enrichment <- function(spatial_similarities) {
   max_fold_enrichments <- vapply(
     spatial_similarities,
@@ -70,26 +60,15 @@ get_likely_state_pairs <- function(similarity_scores) {
   return(likely_state_pairs)
 }
 
-save_file <- function(data, output_file_path, header) {
-  write.table(
-    data,
-    file = output_file_path,
-    sep = ",",
-    col.names = header,
-    row.names = FALSE,
-    quote = FALSE
-  )
-}
-
 main <- function(emission_similarities_file,
                  spatial_similarities_files,
                  weights,
                  output_file_path) {
-  emission_distances <- read_matrix(emission_similarities_file)
+  emission_distances <- read_as_matrix(emission_similarities_file)
   spatial_similarities <- lapply(
     spatial_similarities_files,
     function(file_path) {
-      read_matrix(file_path)
+      read_as_matrix(file_path)
     }
   )
   max_fold_enrichment <- calculate_max_fold_enrichment(spatial_similarities)
@@ -108,13 +87,11 @@ main <- function(emission_similarities_file,
   likely_state_pairs <- get_likely_state_pairs(combined_matrix)
   save_file(
     likely_state_pairs,
-    file.path(output_file_path, "likely_state_pairs.txt"),
-    header = TRUE
+    file.path(output_file_path, "likely_state_pairs.txt")
   )
   save_file(
     combined_matrix,
-    file.path(output_file_path, "similarity_scores.txt"),
-    header = FALSE
+    file.path(output_file_path, "similarity_scores.txt")
   )
 }
 
@@ -124,6 +101,7 @@ spatial_similarities_files <- unlist(strsplit(args[[2]], ","))
 weights <- as.numeric(unlist(strsplit(args[[3]], ",")))
 output_file_path <- args[[4]]
 
+source("IO.R")
 main(
   emission_similarities_file,
   spatial_similarities_files,

--- a/Rscripts/create_blank_bed_file.R
+++ b/Rscripts/create_blank_bed_file.R
@@ -47,7 +47,6 @@ main <- function(bin_size,
   })
 
   blank_bed_data <- dplyr::bind_rows(blank_bed_data_list)
-  print(head(blank_bed_data, 502))
   save_file(blank_bed_data, output_file_path, header = FALSE, sep = "\t")
 }
 

--- a/Rscripts/create_blank_bed_file.R
+++ b/Rscripts/create_blank_bed_file.R
@@ -26,19 +26,6 @@ create_bins <- function(chromosome_name, chromosome_length, bin_size) {
   return(bins)
 }
 
-
-save_file <- function(data, file_path) {
-  data.table::fwrite(
-    data,
-    file = file_path,
-    quote = FALSE,
-    row.names = FALSE,
-    col.names = FALSE,
-    sep = "\t"
-  )
-}
-
-
 main <- function(bin_size,
                  state_assignments_file,
                  chromosome_sizes_file,
@@ -61,7 +48,7 @@ main <- function(bin_size,
 
   blank_bed_data <- dplyr::bind_rows(blank_bed_data_list)
   print(head(blank_bed_data, 502))
-  save_file(blank_bed_data, output_file_path)
+  save_file(blank_bed_data, output_file_path, header = FALSE, sep = "\t")
 }
 
 args <- commandArgs(trailingOnly = TRUE)
@@ -74,5 +61,5 @@ output_file_path <- args[[4]]
 # This behaviour causes bedtools to crash so we prevent this behaviour from
 # ocurring.
 options(scipen = 12)
-
+source("IO.R")
 main(bin_size, state_assignments_file, chromosome_sizes_file, output_file_path)

--- a/Rscripts/emission_similarity.R
+++ b/Rscripts/emission_similarity.R
@@ -27,17 +27,6 @@ create_distances_matrix <- function(emissions_one, emissions_two) {
   return(distances_matrix)
 }
 
-save_file <- function(matrix, file_path) {
-  data.table::fwrite(
-    matrix,
-    file = file_path,
-    quote = FALSE,
-    row.names = FALSE,
-    col.names = TRUE,
-    sep = ","
-  )
-}
-
 main <- function(emission_file_one, emission_file_two, output_file) {
   emissions_one <- data.table::fread(emission_file_one)
   emissions_two <- data.table::fread(emission_file_two)
@@ -63,4 +52,5 @@ emission_file_one <- args[[1]]
 emission_file_two <- args[[2]]
 output_file_path <- args[[3]]
 
+source("IO.R")
 main(emission_file_one, emission_file_two, output_file_path)

--- a/Rscripts/generate_heatmap.R
+++ b/Rscripts/generate_heatmap.R
@@ -1,12 +1,3 @@
-read_matrix <- function(file_path) {
-  matrix <- data.table::fread(
-    file_path,
-    sep = ",",
-    header = TRUE
-  )
-  return(matrix)
-}
-
 reshape_data <- function(data) {
   # Data needs to be reshaped in order to be in the form that will work with
   # ggplot
@@ -41,7 +32,7 @@ generate_heatmap <- function(data) {
 }
 
 main <- function(matrix_file_path, output_file_path) {
-  matrix <- read_matrix(matrix_file_path)
+  matrix <- read_as_data_table(matrix_file_path)
   data <- reshape_data(matrix)
   heatmap <- generate_heatmap(data)
   ggsave(
@@ -56,4 +47,5 @@ matrix_file_path <- args[[1]]
 output_file_path <- args[[2]]
 
 options(bitmapType = "cairo")
+source("IO.R")
 main(matrix_file_path, output_file_path)

--- a/Rscripts/spatial_similarity.R
+++ b/Rscripts/spatial_similarity.R
@@ -97,17 +97,6 @@ create_fold_enrichment_matrix <- function(stats_table) {
   return(fold_enrichment_matrix)
 }
 
-save_matrix <- function(matrix, file_path) {
-  write.table(
-    matrix,
-    file = file_path,
-    quote = FALSE,
-    row.names = FALSE,
-    col.names = TRUE,
-    sep = ","
-  )
-}
-
 main <- function(combined_assignments_file, bin_size, output_file_path) {
   combined_assignments <- data.table::fread(
     combined_assignments_file,
@@ -132,7 +121,7 @@ main <- function(combined_assignments_file, bin_size, output_file_path) {
 
   fold_enrichment_matrix <- create_fold_enrichment_matrix(stats_table)
 
-  save_matrix(fold_enrichment_matrix, output_file_path)
+  save_file(fold_enrichment_matrix, output_file_path)
 }
 
 args <- commandArgs(trailingOnly = TRUE)
@@ -140,4 +129,5 @@ combined_assignments_file <- args[[1]]
 bin_size <- as.numeric(args[[2]])
 output_file_path <- args[[3]]
 
+source("IO.R")
 main(combined_assignments_file, bin_size, output_file_path)


### PR DESCRIPTION
## Description
This pull request will move all IO operations to a single file (IO.R) that is now sourced by each R script. This cuts down on the repetition of each file creating its own function here. Now, should there be a function for this in the first place? I dano. I'm cutting down on lines by assuming that the `sep` should be `","` and that I never want `row.names` to be `TRUE` and I don't want those yucky quotes (so maybe it is a good idea).

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code is consistent in style with the rest of ChromCompare
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
