### PR TITLE
Use the common subset of emissions for similarity matrix

### DIFF
--- a/Rscripts/emission_similarity.R
+++ b/Rscripts/emission_similarity.R
@@ -11,8 +11,8 @@ align_columns <- function(table_one, table_two) {
       " marks. We recommend using a smaller weight for this matrix."
     )
   }
-  table_one <- dplyr::select(table_one, dplyr::all_of(common_marks))
-  table_two <- dplyr::select(table_two, dplyr::all_of(common_marks))
+  table_one <- dplyr::select(table_one, common_marks)
+  table_two <- dplyr::select(table_two, common_marks)
   return(list(table_one, table_two))
 }
 

--- a/Rscripts/emission_similarity.R
+++ b/Rscripts/emission_similarity.R
@@ -6,8 +6,9 @@ align_columns <- function(table_one, table_two) {
   common_marks <- intersect(colnames(table_one), colnames(table_two))
   if (length(colnames(table_two)) != length(colnames(table_one))) {
     message(
-      "Marks between emission files do not align.",
-      "We recommend using a smaller weight for this matrix."
+      "Marks between emission files do not align. Models share ",
+      length(common_marks),
+      " marks. We recommend using a smaller weight for this matrix."
     )
   }
   table_one <- dplyr::select(table_one, dplyr::all_of(common_marks))

--- a/Rscripts/emission_similarity.R
+++ b/Rscripts/emission_similarity.R
@@ -2,9 +2,16 @@ remove_state_column <- function(emissions_table) {
   return(dplyr::select(emissions_table, -"State (Emission order)"))
 }
 
-match_columns <- function(table_one, table_two) {
-  table_one_column_order <- colnames(table_one)
-  table_two <- dplyr::select(table_two, dplyr::all_of(table_one_column_order))
+align_columns <- function(table_one, table_two) {
+  common_marks <- intersect(colnames(table_one), colnames(table_two))
+  if (length(colnames(table_two)) != length(colnames(table_one))) {
+    message(
+      "Marks between emission files do not align.",
+      "We recommend using a smaller weight for this matrix."
+    )
+  }
+  table_one <- dplyr::select(table_one, dplyr::all_of(common_marks))
+  table_two <- dplyr::select(table_two, dplyr::all_of(common_marks))
   return(list(table_one, table_two))
 }
 
@@ -34,9 +41,9 @@ main <- function(emission_file_one, emission_file_two, output_file) {
   emissions_one <- remove_state_column(emissions_one)
   emissions_two <- remove_state_column(emissions_two)
 
-  matched_emissions <- match_columns(emissions_one, emissions_two)
-  emissions_one <- matched_emissions[[1]]
-  emissions_two <- matched_emissions[[2]]
+  aligned_emissions <- align_columns(emissions_one, emissions_two)
+  emissions_one <- aligned_emissions[[1]]
+  emissions_two <- aligned_emissions[[2]]
 
   emission_distances_matrix <-
     create_distances_matrix(


### PR DESCRIPTION
## Description
This pull request will account for the case outlined in #24. The decision was to allow the user to give two emissions matrices that have differing marks. However, if this scenario is detected, a warning message is sent to the error logs. The recommendation in this scenario is to lower the weight associated with the emissions similarity matrix. I decided not to add to the documentation for this as it would be easier to just implement this with the solution to #25. 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code is consistent in style with the rest of ChromCompare
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
